### PR TITLE
🔧 Fix: 찜목록 api 삭제로 인한 에러 해결, 찜목록 레이아웃 수정

### DIFF
--- a/src/api/likes.js
+++ b/src/api/likes.js
@@ -30,3 +30,13 @@ export const getLikes = async postId => {
     console.log("에러 발생", err);
   }
 };
+
+export const getLikedPosts = async () => {
+  try {
+    const res = await client.get(`posts/likes`);
+    // console.log(res.data);
+    return res.data;
+  } catch (err) {
+    console.log("에러 발생", err);
+  }
+};

--- a/src/components/ItemList/Item.js
+++ b/src/components/ItemList/Item.js
@@ -61,10 +61,10 @@ const Item = ({ post, setRefresh }) => {
 };
 
 const Wrapper = styled.div`
-  flex: 1;
-  margin: 0rem 1.7rem;
-  padding: 1.7rem 0rem;
-  //height: 1rem;
+  margin: 0 27px;
+  padding: 27px 0;
+  height: 167px;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   border-bottom: 1px solid #d7d7d7;

--- a/src/components/ItemList/List.js
+++ b/src/components/ItemList/List.js
@@ -2,9 +2,9 @@ import React from "react";
 import { styled } from "styled-components";
 import Item from "./Item";
 
-const List = ({ posts, setRefresh, margintop = "97px", marginbottom = 0 }) => {
+const List = ({ posts, setRefresh, offset = "97px" }) => {
   return (
-    <Wrapper margintop={margintop} marginbottom={marginbottom}>
+    <Wrapper offset={offset}>
       {posts.length === 0 ? (
         <NoList>목록이 없어요.</NoList>
       ) : (
@@ -21,13 +21,11 @@ const Wrapper = styled.div`
   width: 100%;
   height: 100%;
   z-index: -1;
-  /* background: lightgreen; */
   display: flex;
   flex-direction: column;
-  flex: 1;
-  margin-top: ${props => props.margintop};
-  margin-bottom: ${props => props.marginbottom};
-  /* border: 1px solid black; */
+  margin-top: ${props => props.offset};
+  padding-bottom: ${props => props.offset};
+  box-sizing: border-box;
   overflow: scroll;
   -ms-overflow-style: none; /* 인터넷 익스플로러 */
   scrollbar-width: none; /* 파이어폭스 */

--- a/src/pages/FavoritesPage.js
+++ b/src/pages/FavoritesPage.js
@@ -2,26 +2,27 @@ import React, { useEffect, useState } from "react";
 import List from "./../components/ItemList/List";
 import styled from "styled-components";
 import Header from "./../components/Common/Header";
-import { getLikes } from "../api/likes";
+import { getLikedPosts } from "../api/likes";
 
 const FavoritesPage = () => {
   const [loading, setLoading] = useState(true);
   const [posts, setPosts] = useState([]);
+  const [refresh, setRefresh] = useState(0);
 
   useEffect(() => {
     async function fetchData() {
-      const data = await getLikes();
+      const data = await getLikedPosts();
 
       setLoading(false);
       setPosts(data);
     }
     fetchData();
-  }, []);
+  }, [refresh]);
 
   return (
     <Wrapper>
       <Header />
-      <List posts={posts} />
+      <List posts={posts} setRefresh={setRefresh} />
     </Wrapper>
   );
 };
@@ -29,6 +30,7 @@ const FavoritesPage = () => {
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  font-family: "Noto Sans KR";
 `;
 
 export default FavoritesPage;

--- a/src/pages/ItemListPage.js
+++ b/src/pages/ItemListPage.js
@@ -36,12 +36,7 @@ const ItemListPage = () => {
       {loading ? (
         <Loader>loading...</Loader>
       ) : (
-        <List
-          posts={posts}
-          setRefresh={setRefresh}
-          margintop="138px"
-          marginbottom="70px"
-        />
+        <List posts={posts} setRefresh={setRefresh} offset="138px" />
       )}
       <WriteBtn />
     </Wrapper>


### PR DESCRIPTION
찜목록 api가 삭제되어 있어서 getLikedPosts라고 재정의 후 찜목록페이지와 연결.
찜목록에 아이템이 몇개 없을 경우 아이템의 새로길이가 늘어나는 문제와
끝까지 스크롤이 안되는 문제 해결.