### PR TITLE
🐛 채팅 날짜, 시간 오류 수정

### DIFF
--- a/src/components/ChatList/Item.js
+++ b/src/components/ChatList/Item.js
@@ -13,7 +13,10 @@ const Item = ({
   const navigate = useNavigate();
 
   const getElapsedTime = sentAt => {
-    const elapsedSec = new Date().getTime() - sentAt;
+    const elapsedSec =
+      new Date().getTime() -
+      sentAt +
+      new Date().getTimezoneOffset() * 60 * 1000;
 
     //지난 분,시간,일,개월,년
     const elapsedMin = elapsedSec / (1000 * 60);

--- a/src/components/ChatRoom/MessagesContainer.js
+++ b/src/components/ChatRoom/MessagesContainer.js
@@ -79,7 +79,9 @@ const MessagesContainer = () => {
     const sendDate = new Date(
       sentAt - new Date().getTimezoneOffset() * 60 * 1000,
     );
-    const newDate = `${sendDate.getFullYear()}.${sendDate.getMonth()}.${sendDate.getDate()}`;
+    const newDate = `${sendDate.getFullYear()}.${
+      sendDate.getMonth() + 1
+    }.${sendDate.getDate()}`;
     if (date === newDate) {
       return { isNewDate: false, date: newDate };
     } else {


### PR DESCRIPTION
개요
- 채팅방, 채팅목록에서 보이는 날짜, 시간 오류를 수정했습니다.

작업 내용
- UTC 기준인 전송시간 값을 사용자의 로컬 위치 Date값으로 모두 변환 후 시차를 고려해 경과시간 등을 계산했습니다.